### PR TITLE
Update swgemu.sql

### DIFF
--- a/MMOCoreORB/sql/swgemu.sql
+++ b/MMOCoreORB/sql/swgemu.sql
@@ -87,7 +87,7 @@ DROP TABLE IF EXISTS `swgemu`.`account_log`;
 CREATE TABLE  `swgemu`.`account_log` (
   `acclog_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `account_id` int(10) unsigned NOT NULL,
-  `timestamp` datetime NOT NULL,
+  `timestamp` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `ip_address` varchar(15) NOT NULL,
   PRIMARY KEY (`acclog_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
@@ -214,7 +214,7 @@ CREATE TABLE  `swgemu`.`characters` (
   `race` tinyint(2) NOT NULL DEFAULT '0',
   `gender` tinyint(1) NOT NULL DEFAULT '0',
   `template` tinytext NOT NULL,
-  `creation_date` TIMESTAMP NOT NULL,
+  `creation_date` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`character_oid`),
   KEY `acc_idx` (`account_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
@@ -243,7 +243,7 @@ CREATE TABLE  `swgemu`.`characters_dirty` (
   `race` tinyint(2) NOT NULL DEFAULT '0',
   `gender` tinyint(1) NOT NULL DEFAULT '0',
   `template` tinytext NOT NULL,
-  `creation_date` TIMESTAMP NOT NULL,
+  `creation_date` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`character_oid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
@@ -271,7 +271,7 @@ CREATE TABLE  `swgemu`.`deleted_characters` (
   `race` tinyint(2) NOT NULL DEFAULT '0',
   `gender` tinyint(1) NOT NULL DEFAULT '0',
   `template` tinytext NOT NULL,
-  `creation_date` TIMESTAMP NOT NULL,
+  `creation_date` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`character_oid`),
   KEY `acc_idx` (`account_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
@@ -976,7 +976,7 @@ CREATE TABLE  `swgemu`.`mantis_tokens_table` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `owner` int(11) NOT NULL,
   `type` int(11) NOT NULL,
-  `timestamp` datetime NOT NULL,
+  `timestamp` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `expiry` datetime DEFAULT NULL,
   `value` longtext NOT NULL,
   PRIMARY KEY (`id`),


### PR DESCRIPTION
Added default CURRENT_TIMESTAMP due to errors with newer version of MySql. 

> (52 s) [ConfigManager] Configuration update: Core3.Login.SessionDuration = [00:15]
(119 s) [ImageDesignManager] ERROR - unkown customization variable type /private/index_color_2 (119 s) [MySqlDatabase1] ERROR - DatabaseException caused by query: INSERT INTO `characters_dirty` (`character_oid`, `account_id`, `galaxy_id`, `firstname`, `surname`, `race`, `gender`, `template`) VALUES (281474993605105,1,2,'Tequila','Rose',0,0,'object/creature/player/twilek_female.iff') 1364: Field 'creation_date' doesn't have a default value (119 s) [MySqlDatabase1] ERROR - DatabaseException caused by query: DatabaseException caused by query: INSERT INTO `characters_dirty` (`character_oid`, `account_id`, `galaxy_id`, `firstname`, `surname`, `race`, `gender`, `template`) VALUES (281474993605105,1,2,'Tequila','Rose',0,0,'object/creature/player/twilek_female.iff') 1364: Field 'creation_date' doesn't have a default value 1364: Field 'creation_date' doesn't have a default value (119 s) [Console] ERROR - exception caught while running a task DatabaseException caused by query: DatabaseException caused by query: INSERT INTO `characters_dirty` (`character_oid`, `account_id`, `galaxy_id`, `firstname`, `surname`, `race`, `gender`, `template`) VALUES (281474993605105,1,2,'Tequila','Rose',0,0,'object/creature/player/twilek_female.iff') 1364: Field 'creation_date' doesn't have a default value 1364: Field 'creation_date' doesn't have a default value